### PR TITLE
Validate HTML with W3C’s validation service

### DIFF
--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,0 +1,1 @@
+debug.fullTrace=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ rvm:
   - 2.2.6
   - 2.1.10
   - ruby-head
-  - jruby-1.7.19
+  - jruby-9.0.5.0
+  - jruby-9.1.7.0
 before_install: gem update --system && gem install bundler
 after_success: bundle exec codeclimate-test-reporter
 sudo: false

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ $ CHECK_URL=http://www.reevoo.com/sitemap_index.xml sitemap_check
 $ sitemap_check http://www.reevoo.com/sitemap_index.xml
 ```
 
+You can also run `sitemap_check` in validation mode:
+
+```bash
+$ VALIDATE=1 sitemap_check http://www.reevoo.com/sitemap_index.xml
+```
+
+This will validate response bodies with W3C's validation service.
+
 # Docker
 
 ```bash

--- a/lib/sitemap_check/validator.rb
+++ b/lib/sitemap_check/validator.rb
@@ -1,0 +1,60 @@
+require "w3c_validators"
+
+class SitemapCheck
+  class Validator
+    LIMIT = 100
+
+    attr_accessor :logger, :response
+
+    class << self
+      attr_accessor :message_count
+    end
+
+    def initialize(response, logger = Logger.new)
+      self.logger = logger
+      self.response = response
+      self.class.message_count ||= 0
+    end
+
+    def validate
+      validator = W3CValidators::NuValidator.new
+      result = validator.validate_text(response.body)
+      return if result.errors.empty? && result.warnings.empty?
+
+      log_url
+      log_errors(result)
+      log_warnings(result)
+      fail_if_too_many_messages
+    end
+
+    private
+
+    def log_url
+      logger.log "-" * 80
+      logger.log response.effective_url.cyan
+    end
+
+    def log_errors(result)
+      result.errors.each do |e|
+        logger.log "  ERROR: #{e.message}".red
+        logger.log "         #{e.source.inspect}"
+
+        self.class.message_count += 1
+      end
+    end
+
+    def log_warnings(result)
+      result.warnings.each do |w|
+        logger.log "  WARNING: #{w.message}".yellow
+        logger.log "           #{w.source.inspect}"
+
+        self.class.message_count += 1
+      end
+    end
+
+    def fail_if_too_many_messages
+      error = "Stopping because there are more than #{LIMIT} messages."
+      fail error if self.class.message_count > LIMIT
+    end
+  end
+end

--- a/sitemap_check.gemspec
+++ b/sitemap_check.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "~> 1.7"
   spec.add_dependency "typhoeus", "~> 1.1"
   spec.add_dependency "colorize", "~> 0.8"
+  spec.add_dependency "w3c_validators", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.5"

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require "sitemap_check/sitemap"
+
+describe SitemapCheck::Validator do
+  let(:logger) { double(:logger) }
+  let(:response) { double(:response, effective_url: "http://example.com", body: double(:body)) }
+  let(:error) { double(:error, message: "error msg", source: "<foo>") }
+  let(:warning) { double(:error, message: "warning msg", source: "<bar>") }
+
+  let(:errors) { [] }
+  let(:warnings) { [] }
+  let(:messages) { [] }
+
+  subject { described_class.new(response, logger) }
+
+  before do
+    allow_any_instance_of(W3CValidators::NuValidator)
+      .to receive(:validate_text)
+      .and_return(double(:result, errors: errors, warnings: warnings))
+
+    allow(logger).to receive(:log) { |m| messages.push(m) }
+  end
+
+  context "when there are no errors or warnings" do
+    it "doesn't log anything" do
+      expect(logger).not_to receive(:log)
+      subject.validate
+    end
+  end
+
+  context "when there are errors" do
+    let(:errors) { [error] }
+
+    it "logs the URL, error and source" do
+      subject.validate
+
+      expect(messages.join).to include("http://example.com")
+      expect(messages.join).to include("ERROR: error msg")
+      expect(messages.join).to include("<foo>")
+    end
+  end
+
+  context "when there are warnings" do
+    let(:warnings) { [warning] }
+
+    it "logs the URL, warning and source" do
+      subject.validate
+
+      expect(messages.join).to include("http://example.com")
+      expect(messages.join).to include("WARNING: warning msg")
+      expect(messages.join).to include("<bar>")
+    end
+  end
+
+  context "when there are tonnes of messages" do
+    let(:errors) { [error] * 50 }
+    let(:warnings) { [warning] * 51 }
+
+    it "raises an error and stops" do
+      expect { subject.validate }
+        .to raise_error(/more than 100 messages/)
+    end
+  end
+end


### PR DESCRIPTION
I'd like to validate all b2c pages against W3C's validation service to ensure all the HTML is valid before Google crawls the site. This adds a `VALIDATE=1` feature that runs each successful response body through the service and prints any errors/warnings as well as the snippet of HTML that caused that error/warning.

## Screenshot

<img width="956" alt="screen shot 2017-03-10 at 14 01 37" src="https://cloud.githubusercontent.com/assets/892251/23797934/1f718e80-059a-11e7-9213-877f60646e8d.png">
